### PR TITLE
cookie-consent

### DIFF
--- a/src/app/GoogleAnalytics.tsx
+++ b/src/app/GoogleAnalytics.tsx
@@ -2,25 +2,42 @@
 
 import { usePathname } from "next/navigation";
 import { useEffect } from "react";
+import Script from "next/script";
+import { useConsent } from "@/context/ConsentContext";
 
 const GA_MEASUREMENT_ID = "G-BT21FKPMCH";
 
 declare global {
   interface Window {
-    gtag: any;
+    gtag: (...args: any[]) => void;
+    dataLayer: any[];
   }
 }
 
 export default function GoogleAnalytics() {
   const pathname = usePathname();
+  const { consent } = useConsent();
+  const analyticsEnabled = consent.preferences.analytics;
 
+  // Fire page-view on soft navigations after GA is already loaded
   useEffect(() => {
-    if (!window.gtag) return;
+    if (!analyticsEnabled) return;
+    if (typeof window.gtag !== "function") return;
+    window.gtag("config", GA_MEASUREMENT_ID, { page_path: pathname });
+  }, [pathname, analyticsEnabled]);
 
-    window.gtag("config", GA_MEASUREMENT_ID, {
-      page_path: pathname,
-    });
-  }, [pathname]);
+  if (!analyticsEnabled) return null;
 
-  return null;
+  return (
+    <Script
+      id="ga-script"
+      strategy="afterInteractive"
+      src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+      onLoad={() => {
+        // gtag('js', new Date()) is required — without it GA4 never initializes
+        window.gtag("js", new Date());
+        window.gtag("config", GA_MEASUREMENT_ID, { page_path: pathname });
+      }}
+    />
+  );
 }

--- a/src/app/GoogleAnalytics.tsx
+++ b/src/app/GoogleAnalytics.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import React, { useEffect } from "react";
 import { usePathname } from "next/navigation";
-import { useEffect } from "react";
 import Script from "next/script";
 import { useConsent } from "@/context/ConsentContext";
 
@@ -18,10 +18,15 @@ export default function GoogleAnalytics() {
   const pathname = usePathname();
   const { consent } = useConsent();
   const analyticsEnabled = consent.preferences.analytics;
+  // Tracks whether the GA script has already run its initial config so the
+  // useEffect below never sends a duplicate page_view on the first load.
+  const initializedRef = React.useRef(false);
 
-  // Fire page-view on soft navigations after GA is already loaded
+  // Fire page-view on soft navigations — but skip the very first call because
+  // onLoad already sends the initial config.
   useEffect(() => {
     if (!analyticsEnabled) return;
+    if (!initializedRef.current) return; // wait until onLoad has run
     if (typeof window.gtag !== "function") return;
     window.gtag("config", GA_MEASUREMENT_ID, { page_path: pathname });
   }, [pathname, analyticsEnabled]);
@@ -34,9 +39,11 @@ export default function GoogleAnalytics() {
       strategy="afterInteractive"
       src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
       onLoad={() => {
-        // gtag('js', new Date()) is required — without it GA4 never initializes
+        // gtag('js', new Date()) is required — without it GA4 never initializes.
+        // This is the single authoritative initial config call.
         window.gtag("js", new Date());
         window.gtag("config", GA_MEASUREMENT_ID, { page_path: pathname });
+        initializedRef.current = true;
       }}
     />
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,8 @@ import Footer from "@/components/Footer";
 import ChatBot from "./chat";
 import Script from "next/script";
 import GoogleAnalytics from "./GoogleAnalytics";
+import { ConsentProvider } from "@/context/ConsentContext";
+import CookieBanner from "@/components/CookieConsent/CookieBanner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -78,16 +80,21 @@ export default function RootLayout({
           rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
         />
-        <Script
-          strategy="afterInteractive"
-          src="https://www.googletagmanager.com/gtag/js?id=G-BT21FKPMCH"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
+        {/*
+          Google Consent Mode v2 — initialise dataLayer and set ALL consent
+          signals to "denied" before any analytics script loads.
+          This runs inline/synchronously so GA never fires without consent.
+          The ConsentContext will call gtag('consent','update',...) once
+          the user's stored preference (or fresh decision) is applied.
+        */}
+        <Script id="consent-mode-default" strategy="beforeInteractive">
           {`
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', 'G-BT21FKPMCH');
+            gtag('consent', 'default', {
+              analytics_storage: 'denied',
+              wait_for_update: 500
+            });
           `}
         </Script>
         <Script
@@ -111,14 +118,18 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased font-gilroy`}>
-        <GoogleAnalytics />
-        <div id="modal-root" />
-        <Header />
-        {children}
-        <Footer />
-        {/* <GoToTopButton /> */}
-        <ChatBot />
+        className={`${geistSans.variable} ${geistMono.variable} antialiased font-gilroy`}
+      >
+        <ConsentProvider>
+          <GoogleAnalytics />
+          <div id="modal-root" />
+          <Header />
+          {children}
+          <Footer />
+          {/* <GoToTopButton /> */}
+          <ChatBot />
+          <CookieBanner />
+        </ConsentProvider>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -80,13 +80,6 @@ export default function RootLayout({
           rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
         />
-        {/*
-          Google Consent Mode v2 — initialise dataLayer and set ALL consent
-          signals to "denied" before any analytics script loads.
-          This runs inline/synchronously so GA never fires without consent.
-          The ConsentContext will call gtag('consent','update',...) once
-          the user's stored preference (or fresh decision) is applied.
-        */}
         <Script id="consent-mode-default" strategy="beforeInteractive">
           {`
             window.dataLayer = window.dataLayer || [];

--- a/src/components/CookieConsent/CookieBanner.tsx
+++ b/src/components/CookieConsent/CookieBanner.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Shield } from "lucide-react";
+import { useConsent } from "@/context/ConsentContext";
+
+export default function CookieBanner() {
+  const { showBanner, acceptAll, rejectAll } = useConsent();
+
+  if (!showBanner) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-label="Cookie consent"
+      className="fixed bottom-0 left-0 right-0 z-[9999] p-4 sm:p-6"
+    >
+      <div className="max-w-3xl mx-auto bg-[#191b2b] border border-white/10 rounded-2xl shadow-2xl shadow-black/50 p-5">
+        <div className="flex flex-col sm:flex-row gap-4 sm:items-center">
+          {/* Text — icon inline with title on all screen sizes */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2.5 mb-1">
+              <div className="flex-shrink-0 w-7 h-7 rounded-lg bg-white/10 flex items-center justify-center">
+                <Shield className="w-4 h-4 text-white" />
+              </div>
+              <p className="text-white font-semibold text-sm sm:text-base">
+                We value your privacy
+              </p>
+            </div>
+            <p className="text-white/60 text-xs sm:text-sm leading-relaxed pl-9">
+              We use cookies to analyse site traffic via Google Analytics,
+              helping us improve your experience. No data is collected unless
+              you accept.{" "}
+              {/* <a
+                href="#"
+                className="underline underline-offset-2 text-white/80 hover:text-white transition-colors"
+              >
+                Privacy Policy
+              </a> */}
+            </p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex flex-row gap-2 flex-shrink-0 pl-9 sm:pl-0">
+            <button
+              onClick={rejectAll}
+              className="px-5 py-2.5 rounded-xl border border-white/15 text-white/60 text-sm font-medium hover:bg-white/5 hover:text-white/80 transition-colors focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#181B2B] cursor-pointer"
+            >
+              Reject
+            </button>
+            <button
+              onClick={acceptAll}
+              className="px-5 py-2.5 rounded-xl bg-white text-[#181B2B] text-sm font-semibold hover:bg-white/90 transition-colors focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#181B2B] cursor-pointer"
+            >
+              Accept
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CookieConsent/CookieBanner.tsx
+++ b/src/components/CookieConsent/CookieBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Shield } from "lucide-react";
+import { Settings, Shield } from "lucide-react";
 import { useConsent } from "@/context/ConsentContext";
 
 export default function CookieBanner() {
@@ -30,7 +30,13 @@ export default function CookieBanner() {
             <p className="text-white/60 text-xs sm:text-sm leading-relaxed pl-9">
               We use cookies to analyse site traffic via Google Analytics,
               helping us improve your experience. No data is collected unless
-              you accept.{" "}
+              you accept and you can change your preferences at any time using
+              the{" "}
+              <span className="text-yellow-100 inline-flex items-center gap-1 align-middle translate-y-[-0.5px]">
+                <Settings size={13} strokeWidth={1.8} />
+                <span>Settings </span>
+              </span>
+              {"  "}from the footer.
               {/* <a
                 href="#"
                 className="underline underline-offset-2 text-white/80 hover:text-white transition-colors"

--- a/src/components/CookieConsent/CookieSettingsModal.tsx
+++ b/src/components/CookieConsent/CookieSettingsModal.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Settings, X, ShieldCheck, BarChart2 } from "lucide-react";
+import { useConsent } from "@/context/ConsentContext";
+
+export default function CookieSettingsModal() {
+  const { consent, savePreferences } = useConsent();
+  const [open, setOpen] = useState(false);
+  const [analyticsOn, setAnalyticsOn] = useState(consent.preferences.analytics);
+
+  // Sync toggle with latest stored value every time the modal opens
+  const handleOpen = () => {
+    setAnalyticsOn(consent.preferences.analytics);
+    setOpen(true);
+  };
+
+  const handleClose = () => setOpen(false);
+
+  const handleSave = () => {
+    savePreferences({ necessary: true, analytics: analyticsOn });
+    setOpen(false);
+  };
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  // Prevent body scroll while modal is open
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  return (
+    <>
+      {/* Trigger — placed inline in the Footer */}
+      <button
+        onClick={handleOpen}
+        className="flex items-center gap-1.5 text-[#AAAAAA] hover:text-white transition-colors text-xs cursor-pointer"
+        aria-label="Open cookie settings"
+      >
+        <Settings size={13} strokeWidth={1.8} />
+        <span>Settings</span>
+      </button>
+
+      {/* Backdrop + modal */}
+      {open && (
+        <div
+          className="fixed inset-0 z-[10000] flex items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Cookie preferences"
+        >
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={handleClose}
+            aria-hidden="true"
+          />
+
+          {/* Card */}
+          <div className="relative z-10 w-full max-w-md bg-[#191b2b] border border-white/10 rounded-2xl shadow-2xl shadow-black/60 flex flex-col">
+            {/* Header */}
+            <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b border-white/10">
+              <div className="flex items-center gap-2.5">
+                <div className="w-8 h-8 rounded-lg bg-white/10 flex items-center justify-center flex-shrink-0">
+                  <Settings className="w-4 h-4 text-white" />
+                </div>
+                <div>
+                  <h2 className="text-white font-semibold text-base leading-tight">
+                    Cookie Settings
+                  </h2>
+                  <p className="text-white/50 text-xs mt-0.5">
+                    Manage your cookie preferences
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={handleClose}
+                className="w-8 h-8 rounded-lg flex items-center justify-center text-white/40 hover:text-white hover:bg-white/10 transition-colors cursor-pointer"
+                aria-label="Close"
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            {/* Body */}
+            <div className="px-6 py-5 flex flex-col gap-4">
+              {/* Necessary — always on, non-interactive */}
+              <div className="flex items-start gap-4 p-4 rounded-xl bg-white/5 border border-white/8">
+                <div className="w-8 h-8 rounded-lg bg-white/10 flex items-center justify-center flex-shrink-0 mt-0.5">
+                  <ShieldCheck className="w-4 h-4 text-white/70" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-white text-sm font-medium">
+                    Necessary Cookies
+                  </p>
+                  <p className="text-white/50 text-xs mt-1 leading-relaxed">
+                    Required for the site to function. Cannot be disabled.
+                  </p>
+                </div>
+                {/* Always-on pill */}
+                <span className="flex-shrink-0 mt-0.5 text-xs px-2.5 py-1 rounded-full bg-white/10 text-white/50 font-medium">
+                  Always on
+                </span>
+              </div>
+
+              {/* Analytics — toggleable */}
+              <div className="flex items-start gap-4 p-4 rounded-xl bg-white/5 border border-white/8">
+                <div className="w-8 h-8 rounded-lg bg-white/10 flex items-center justify-center flex-shrink-0 mt-0.5">
+                  <BarChart2 className="w-4 h-4 text-white/70" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-white text-sm font-medium">
+                    Analytics Cookies
+                  </p>
+                  <p className="text-white/50 text-xs mt-1 leading-relaxed">
+                    Help us understand how visitors interact with our site via
+                    Google Analytics. No personal data is collected.
+                  </p>
+                </div>
+                {/* Toggle */}
+                <button
+                  role="switch"
+                  aria-checked={analyticsOn}
+                  onClick={() => setAnalyticsOn((v) => !v)}
+                  className={`flex-shrink-0 mt-0.5 relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#191b2b] cursor-pointer ${
+                    analyticsOn ? "bg-white" : "bg-white/20"
+                  }`}
+                  aria-label="Toggle analytics cookies"
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-[#191b2b] shadow-sm transition-transform duration-200 ${
+                      analyticsOn ? "translate-x-6" : "translate-x-1"
+                    }`}
+                  />
+                </button>
+              </div>
+            </div>
+
+            {/* Footer */}
+            <div className="px-6 pb-5 flex items-center justify-between gap-4 border-t border-white/10 pt-4">
+              <p className="text-white/40 cursor-pointer hover:text-white/70 text-xs underline underline-offset-2 transition-colors">
+                Privacy Policy
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleClose}
+                  className="px-4 py-2 rounded-xl border border-white/15 text-white/60 text-sm font-medium hover:bg-white/5 hover:text-white/80 transition-colors cursor-pointer"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleSave}
+                  className="px-5 py-2 rounded-xl bg-white text-[#181B2B] text-sm font-semibold hover:bg-white/90 transition-colors cursor-pointer"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import { Linkedin, Mails } from "lucide-react";
 import Link from "next/link";
 import Logo from "@/assets/logo/logo.svg";
+import CookieSettingsModal from "@/components/CookieConsent/CookieSettingsModal";
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
@@ -18,46 +19,53 @@ export default function Footer() {
           </div>
 
           <div className="flex flex-col sm:flex-row items-center justify-center order-1 lg:order-2 gap-4">
-            <nav className="flex flex-nowrap justify-center gap-2 sm:gap-4 text-sm lg:text-base text-white">
-              <Link href="/about" className="hover:underline">
-                Who We Are
-              </Link>
-              <span className="text-gray-500 inline">/</span>
+            <div className="flex flex-col items-start gap-1">
+              <nav className="flex flex-nowrap justify-center gap-2 sm:gap-4 text-sm lg:text-base text-white">
+                <Link href="/about" className="hover:underline">
+                  Who We Are
+                </Link>
+                <span className="text-gray-500 inline">/</span>
 
-              <Link href="/services/consulting" className="hover:underline">
-                Services
-              </Link>
-              <span className="text-gray-500 inline">/</span>
-              <Link href="/products" className="hover:underline">
-                Products
-              </Link>
-              <span className="text-gray-500 inline">/</span>
+                <Link href="/services/consulting" className="hover:underline">
+                  Services
+                </Link>
+                <span className="text-gray-500 inline">/</span>
+                <Link href="/products" className="hover:underline">
+                  Products
+                </Link>
+                <span className="text-gray-500 inline">/</span>
 
-              <Link href="/careers" className="hidden lg:flex hover:underline">
-                Careers
-              </Link>
-              <span className="hidden lg:inline text-gray-500">/</span>
+                <Link
+                  href="/careers"
+                  className="hidden lg:flex hover:underline"
+                >
+                  Careers
+                </Link>
+                <span className="hidden lg:inline text-gray-500">/</span>
 
-              <Link href="/contact" className="hover:underline">
-                Contact
-              </Link>
-            </nav>
-
+                <Link href="/contact" className="hover:underline">
+                  Contact
+                </Link>
+              </nav>
+            </div>
             <div className="flex gap-6 justify-center text-[#AAAAAA] sm:-mt-1">
               <a
                 href="https://www.linkedin.com/company/evoltechgroup/"
                 className="hover:opacity-80"
                 aria-label="Connect on LinkedIn"
                 target="_blank"
-                rel="noopener noreferrer">
+                rel="noopener noreferrer"
+              >
                 <Linkedin size={15} />
               </a>
               <a
                 href="mailto:info@evoltechgroup.com"
                 className="hover:opacity-80"
-                aria-label="Send Mail">
+                aria-label="Send Mail"
+              >
                 <Mails size={15} />
               </a>
+              <CookieSettingsModal />
             </div>
           </div>
         </div>

--- a/src/context/ConsentContext.tsx
+++ b/src/context/ConsentContext.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import {
+  ALL_ACCEPTED,
+  ALL_REJECTED,
+  ConsentPreferences,
+  ConsentState,
+  applyGtagConsent,
+  getDefaultConsent,
+  loadConsent,
+  saveConsent,
+} from "@/lib/consent";
+
+interface ConsentContextValue {
+  consent: ConsentState;
+  showBanner: boolean;
+  acceptAll: () => void;
+  rejectAll: () => void;
+}
+
+const ConsentContext = createContext<ConsentContextValue | null>(null);
+
+export function ConsentProvider({ children }: { children: React.ReactNode }) {
+  const [consent, setConsent] = useState<ConsentState>(getDefaultConsent);
+  // Stays false until after the first useEffect — prevents banner flash
+  // on returning visitors whose consent is already stored in localStorage.
+  const [mounted, setMounted] = useState(false);
+
+  // Hydrate from storage after mount (client-only)
+  useEffect(() => {
+    const stored = loadConsent();
+    setConsent(stored);
+
+    // If a previous decision exists, apply it to GA Consent Mode immediately
+    if (stored.hasDecided) {
+      applyGtagConsent(stored.preferences);
+    }
+
+    setMounted(true);
+  }, []);
+
+  const applyAndSave = useCallback((prefs: ConsentPreferences) => {
+    const newState = saveConsent(prefs);
+    setConsent(newState);
+    applyGtagConsent(prefs);
+  }, []);
+
+  const acceptAll = useCallback(
+    () => applyAndSave(ALL_ACCEPTED),
+    [applyAndSave],
+  );
+  const rejectAll = useCallback(
+    () => applyAndSave(ALL_REJECTED),
+    [applyAndSave],
+  );
+
+  // Only show banner after hydration — avoids flash for returning visitors
+  const showBanner = mounted && !consent.hasDecided;
+
+  return (
+    <ConsentContext.Provider
+      value={{ consent, showBanner, acceptAll, rejectAll }}
+    >
+      {children}
+    </ConsentContext.Provider>
+  );
+}
+
+export function useConsent(): ConsentContextValue {
+  const ctx = useContext(ConsentContext);
+  if (!ctx) throw new Error("useConsent must be used within ConsentProvider");
+  return ctx;
+}

--- a/src/context/ConsentContext.tsx
+++ b/src/context/ConsentContext.tsx
@@ -23,6 +23,7 @@ interface ConsentContextValue {
   showBanner: boolean;
   acceptAll: () => void;
   rejectAll: () => void;
+  savePreferences: (prefs: ConsentPreferences) => void;
 }
 
 const ConsentContext = createContext<ConsentContextValue | null>(null);
@@ -60,13 +61,17 @@ export function ConsentProvider({ children }: { children: React.ReactNode }) {
     () => applyAndSave(ALL_REJECTED),
     [applyAndSave],
   );
+  const savePreferences = useCallback(
+    (prefs: ConsentPreferences) => applyAndSave(prefs),
+    [applyAndSave],
+  );
 
   // Only show banner after hydration — avoids flash for returning visitors
   const showBanner = mounted && !consent.hasDecided;
 
   return (
     <ConsentContext.Provider
-      value={{ consent, showBanner, acceptAll, rejectAll }}
+      value={{ consent, showBanner, acceptAll, rejectAll, savePreferences }}
     >
       {children}
     </ConsentContext.Provider>

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -27,13 +27,29 @@ export function getDefaultConsent(): ConsentState {
   };
 }
 
-/** Load from localStorage; falls back to default if missing or version mismatch */
+/** Returns true when the parsed value has all required fields with correct types */
+function isValidConsentState(v: unknown): v is ConsentState {
+  if (!v || typeof v !== "object") return false;
+  const s = v as Record<string, unknown>;
+  if (typeof s.hasDecided !== "boolean") return false;
+  if (typeof s.version !== "string") return false;
+  const prefs = s.preferences;
+  if (!prefs || typeof prefs !== "object") return false;
+  const p = prefs as Record<string, unknown>;
+  if (p.necessary !== true) return false;
+  if (typeof p.analytics !== "boolean") return false;
+  return true;
+}
+
+/** Load from localStorage; falls back to default if missing, corrupted, or version mismatch */
 export function loadConsent(): ConsentState {
   if (typeof window === "undefined") return getDefaultConsent();
   try {
     const raw = localStorage.getItem(CONSENT_KEY);
     if (!raw) return getDefaultConsent();
-    const parsed = JSON.parse(raw) as ConsentState;
+    const parsed: unknown = JSON.parse(raw);
+    // Validate shape before trusting any field
+    if (!isValidConsentState(parsed)) return getDefaultConsent();
     // Re-prompt when the consent policy version changes
     if (parsed.version !== CONSENT_VERSION) return getDefaultConsent();
     return parsed;
@@ -53,16 +69,30 @@ export function saveConsent(preferences: ConsentPreferences): ConsentState {
 
   if (typeof window === "undefined") return state;
 
-  localStorage.setItem(CONSENT_KEY, JSON.stringify(state));
+  // Wrap every storage write in try/catch — storage may be blocked (quota,
+  // private-browsing restrictions, etc.). The in-memory state is always returned
+  // so the consent flow works even when persistence fails.
+  try {
+    localStorage.setItem(CONSENT_KEY, JSON.stringify(state));
+  } catch {
+    // localStorage unavailable — in-memory state will still be used for this session
+  }
 
-  // Persisted cookie so server/middleware can read consent without JS
-  const maxAge = 365 * 24 * 60 * 60; // 1 year
-  document.cookie = [
-    `${CONSENT_KEY}=${encodeURIComponent(JSON.stringify(state))}`,
-    `max-age=${maxAge}`,
-    "path=/",
-    "SameSite=Lax",
-  ].join("; ");
+  try {
+    // Persisted cookie so server/middleware can read consent without JS
+    const maxAge = 365 * 24 * 60 * 60; // 1 year
+    const parts = [
+      `${CONSENT_KEY}=${encodeURIComponent(JSON.stringify(state))}`,
+      `max-age=${maxAge}`,
+      "path=/",
+      "SameSite=Lax",
+    ];
+    // Add Secure on HTTPS so the cookie is never sent over a plain-HTTP request
+    if (location.protocol === "https:") parts.push("Secure");
+    document.cookie = parts.join("; ");
+  } catch {
+    // Cookie write unavailable — localStorage copy is sufficient
+  }
 
   return state;
 }

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,89 @@
+// GDPR Consent Management — types, storage helpers, and Consent Mode v2 signals
+
+export const CONSENT_VERSION = "1.0";
+export const CONSENT_KEY = "evoltech_cookie_consent";
+
+export interface ConsentPreferences {
+  necessary: true; // always on — cannot be disabled
+  analytics: boolean; // Google Analytics (GA4)
+}
+
+export interface ConsentState {
+  hasDecided: boolean;
+  preferences: ConsentPreferences;
+  timestamp: string; // ISO datetime of the decision
+  version: string; // re-prompt when policy version changes
+}
+
+export function getDefaultConsent(): ConsentState {
+  return {
+    hasDecided: false,
+    preferences: {
+      necessary: true,
+      analytics: false,
+    },
+    timestamp: "",
+    version: CONSENT_VERSION,
+  };
+}
+
+/** Load from localStorage; falls back to default if missing or version mismatch */
+export function loadConsent(): ConsentState {
+  if (typeof window === "undefined") return getDefaultConsent();
+  try {
+    const raw = localStorage.getItem(CONSENT_KEY);
+    if (!raw) return getDefaultConsent();
+    const parsed = JSON.parse(raw) as ConsentState;
+    // Re-prompt when the consent policy version changes
+    if (parsed.version !== CONSENT_VERSION) return getDefaultConsent();
+    return parsed;
+  } catch {
+    return getDefaultConsent();
+  }
+}
+
+/** Persist consent to both localStorage and a first-party cookie (server-readable) */
+export function saveConsent(preferences: ConsentPreferences): ConsentState {
+  const state: ConsentState = {
+    hasDecided: true,
+    preferences,
+    timestamp: new Date().toISOString(),
+    version: CONSENT_VERSION,
+  };
+
+  if (typeof window === "undefined") return state;
+
+  localStorage.setItem(CONSENT_KEY, JSON.stringify(state));
+
+  // Persisted cookie so server/middleware can read consent without JS
+  const maxAge = 365 * 24 * 60 * 60; // 1 year
+  document.cookie = [
+    `${CONSENT_KEY}=${encodeURIComponent(JSON.stringify(state))}`,
+    `max-age=${maxAge}`,
+    "path=/",
+    "SameSite=Lax",
+  ].join("; ");
+
+  return state;
+}
+
+/** Push a Consent Mode v2 update so GA/GTM respects the user's decision */
+export function applyGtagConsent(preferences: ConsentPreferences): void {
+  if (typeof window === "undefined") return;
+  const w = window as any;
+  if (typeof w.gtag !== "function") return;
+
+  w.gtag("consent", "update", {
+    analytics_storage: preferences.analytics ? "granted" : "denied",
+  });
+}
+
+export const ALL_ACCEPTED: ConsentPreferences = {
+  necessary: true,
+  analytics: true,
+};
+
+export const ALL_REJECTED: ConsentPreferences = {
+  necessary: true,
+  analytics: false,
+};


### PR DESCRIPTION
This pull request implements a full GDPR-compliant cookie consent system with Google Consent Mode v2 integration. It ensures Google Analytics is only loaded and fired after user consent, provides a user-friendly cookie consent banner, and manages consent preferences via localStorage and cookies. Key changes include introducing a new consent context/provider, a cookie banner UI, and updating analytics initialization to respect user choices.

**Consent Management & Context**

* Added `ConsentContext` and `ConsentProvider` in `src/context/ConsentContext.tsx` to handle consent state, preferences, and banner visibility, with helpers to accept/reject all cookies.
* Created `src/lib/consent.ts` with types, storage helpers, and functions to persist consent decisions and send Consent Mode v2 signals to Google Analytics.

**User Interface**

* Added a new `CookieBanner` component in `src/components/CookieConsent/CookieBanner.tsx` to prompt users for consent, with accept/reject actions wired to the consent context.
* Wrapped the app in `ConsentProvider` and rendered `CookieBanner` in `src/app/layout.tsx` to ensure consent state is available throughout the app and the banner is shown as needed. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R16-R17) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L114-R132)

**Google Analytics & Consent Mode**

* Updated `GoogleAnalytics.tsx` to only load and fire Google Analytics if analytics consent is granted, and to send page view events on navigation after consent.
* Inserted a synchronous inline script in `layout.tsx` to initialize `dataLayer` and set all consent signals to "denied" by default, ensuring no analytics are loaded before user consent.